### PR TITLE
DeviceEngagedException 1st Fix

### DIFF
--- a/src/main/java/com/testvagrant/ekam/devicemanager/DeviceCache.java
+++ b/src/main/java/com/testvagrant/ekam/devicemanager/DeviceCache.java
@@ -12,7 +12,11 @@ import com.testvagrant.ekam.devicemanager.models.TargetDetails;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.testvagrant.ekam.logger.EkamLogger.ekamLogger;
 
@@ -83,16 +87,14 @@ public class DeviceCache extends SharedDataCache<TargetDetails> {
     }
 
     if (isAvailable(predicate)) {
-      Optional<TargetDetails> availableDevice =
-          availableCache.asMap().values().stream().filter(predicate).findAny();
-
-      if (availableDevice.isPresent()) {
-        TargetDetails targetDetails = availableDevice.get();
-        if (lock) lock(targetDetails.getUdid());
-        return targetDetails;
-      }
+      List<TargetDetails> availableDevices =
+          availableCache.asMap().values().stream().filter(predicate).collect(Collectors.toList());
+      int randomElementIndex
+              = (int) (ThreadLocalRandom.current().nextInt(availableDevices.size()) % availableDevices.size());
+      TargetDetails targetDetails = availableDevices.get(randomElementIndex);
+      if (lock) lock(targetDetails.getUdid());
+      return targetDetails;
     }
-
     throw new DeviceEngagedException();
   }
 

--- a/src/main/java/com/testvagrant/ekam/devicemanager/devicefinder/BrowserStackDeviceFinder.java
+++ b/src/main/java/com/testvagrant/ekam/devicemanager/devicefinder/BrowserStackDeviceFinder.java
@@ -31,7 +31,7 @@ public class BrowserStackDeviceFinder {
         new DeviceFiltersManager().createDeviceFilters(platform, filters);
     TargetDetails availableDevice =
         BrowserStackDeviceManagerProvider.deviceManager(username, accesskey)
-            .getAvailableDevice(predicate, true);
+            .getAvailableDevice(predicate, Boolean.parseBoolean(System.getProperty("cloud.browserstack.cache.lock","true")));
     return availableDevice;
   }
 }

--- a/src/main/java/com/testvagrant/ekam/devicemanager/devicefinder/PCloudyDeviceFinder.java
+++ b/src/main/java/com/testvagrant/ekam/devicemanager/devicefinder/PCloudyDeviceFinder.java
@@ -32,7 +32,7 @@ public class PCloudyDeviceFinder {
         new DeviceFiltersManager().createDeviceFilters(platform, filters);
     TargetDetails availableDevice =
         PCloudyDeviceManagerProvider.deviceManager(host, username, accesskey)
-            .getAvailableDevice(predicate, true);
+            .getAvailableDevice(predicate, Boolean.parseBoolean(System.getProperty("cloud.pcloudy.cache.lock","true")));
     return availableDevice;
   }
 }

--- a/src/test/java/com/testvagrant/ekam/devicemanager/devicecache/DeviceEngagedTests.java
+++ b/src/test/java/com/testvagrant/ekam/devicemanager/devicecache/DeviceEngagedTests.java
@@ -3,13 +3,17 @@ package com.testvagrant.ekam.devicemanager.devicecache;
 import com.testvagrant.ekam.devicemanager.DeviceCache;
 import com.testvagrant.ekam.devicemanager.DeviceFiltersManager;
 import com.testvagrant.ekam.devicemanager.DeviceManager;
+import com.testvagrant.ekam.devicemanager.exceptions.DeviceEngagedException;
+import com.testvagrant.ekam.devicemanager.exceptions.NoSuchDeviceException;
 import com.testvagrant.ekam.devicemanager.models.DeviceFilter;
 import com.testvagrant.ekam.devicemanager.models.DeviceFilters;
 import com.testvagrant.ekam.devicemanager.models.EkamSupportedPlatforms;
 import com.testvagrant.ekam.devicemanager.models.TargetDetails;
 import org.junit.jupiter.api.Assertions;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 
@@ -17,60 +21,95 @@ public class DeviceEngagedTests {
 
     @Test
     public void shouldGiveDifferentDevicesWhenTheDeviceLockIsEnabled(){
-        TargetDetails pixel3a=
-                TargetDetails.builder()
-                        .platform(EkamSupportedPlatforms.ANDROID)
-                        .name("Google Pixel 3a")
-                        .udid("12")
-                        .build();
-        TargetDetails pixel3b =
-                TargetDetails.builder()
-                        .platform(EkamSupportedPlatforms.ANDROID)
-                        .name("Google Pixel 3b")
-                        .udid("12")
-                        .build();
-
-        List<TargetDetails>targets=List.of(pixel3a,pixel3b);
+        List<TargetDetails> targets = new ArrayList<>();
+        for(int i=0;i<2;i++)
+            targets.add(getTargetDetails());
 
         DeviceCache deviceCache=new DeviceCache(targets);
-
-        Predicate<TargetDetails> predicate = getTargetDetailsPredicate("Google Pixel 3", "android");
+        Predicate<TargetDetails> predicate = getTargetDetailsPredicate( "Google","android");
 
         TargetDetails availableDevice = new DeviceManager(deviceCache).getAvailableDevice(predicate, true);
         TargetDetails availableDevice1 = new DeviceManager(deviceCache).getAvailableDevice(predicate, true);
-        TargetDetails availableDevice2 = new DeviceManager(deviceCache).getAvailableDevice(predicate, true);
 
         Assertions.assertNotEquals(availableDevice.getName(),availableDevice1.getName());
     }
+
     @Test
-    public void shouldGiveSameDeviceWhenTheDeviceLockIsDisabled(){
-        TargetDetails pixel3c=
-                TargetDetails.builder()
-                        .platform(EkamSupportedPlatforms.ANDROID)
-                        .name("Google Pixel 3c")
-                        .udid("12")
-                        .build();
-
-        TargetDetails pixel3b =
-                TargetDetails.builder()
-                        .platform(EkamSupportedPlatforms.ANDROID)
-                        .name("Google Pixel 3b")
-                        .udid("12")
-                        .build();
-
-        List<TargetDetails>targets=List.of(pixel3c,pixel3b);
+    public void shouldGiveRandomDevicesWhenTheDeviceLockIsDisabled(){
+        List<TargetDetails> targets = new ArrayList<>();
+        for(int i=0;i<10;i++)
+            targets.add(getTargetDetails());
 
         DeviceCache deviceCache=new DeviceCache(targets);
-
-        Predicate<TargetDetails> predicate = getTargetDetailsPredicate("Google Pixel 3", "android");
+        Predicate<TargetDetails> predicate = getTargetDetailsPredicate( "android");
 
         TargetDetails availableDevice = new DeviceManager(deviceCache).getAvailableDevice(predicate, false);
         TargetDetails availableDevice1 = new DeviceManager(deviceCache).getAvailableDevice(predicate, false);
-        TargetDetails availableDevice2 = new DeviceManager(deviceCache).getAvailableDevice(predicate, false);
 
-        Assertions.assertEquals(availableDevice.getName().toString(),availableDevice1.getName().toString());
+        Assertions.assertNotEquals(availableDevice.getName(),availableDevice1.getName());
     }
 
+    @Test
+    public void shouldThrowDeviceEngagedExceptionWhenAllTheAvailableDevicesAreLocked(){
+        List<TargetDetails> targets = new ArrayList<>();
+        for(int i=0;i<5;i++)
+            targets.add(getTargetDetails());
+
+        DeviceCache deviceCache=new DeviceCache(targets);
+        Predicate<TargetDetails> predicate = getTargetDetailsPredicate( "android");
+
+        Assertions.assertThrows(DeviceEngagedException.class,()->{
+            for(int i=0;i<8;i++) {
+                TargetDetails availableDevice = new DeviceManager(deviceCache).getAvailableDevice(predicate, true);
+            }
+        });
+    }
+
+    @Test
+    public void shouldThrowNoSuchDeviceAvailableExceptionIfThereAreNoDevices(){
+        List<TargetDetails> targets = new ArrayList<>();
+        DeviceCache deviceCache=new DeviceCache(targets);
+        Predicate<TargetDetails> predicate = getTargetDetailsPredicate( "android");
+        Assertions.assertThrows(NoSuchDeviceException.class,()->new DeviceManager(deviceCache).getAvailableDevice(predicate));
+    }
+
+    @Test
+    public void shouldLockAndUnLockTheDevicesWhenSpecified(){
+        TargetDetails pixel3 =
+                TargetDetails.builder()
+                        .platform(EkamSupportedPlatforms.ANDROID)
+                        .name("Google Pixel 3")
+                        .udid("321")
+                        .build();
+        TargetDetails pixel4 =
+                TargetDetails.builder()
+                        .platform(EkamSupportedPlatforms.ANDROID)
+                        .name("Google Pixel 4")
+                        .udid("236")
+                        .build();
+        List<TargetDetails> targets =List.of(pixel3,pixel4);
+
+        DeviceCache deviceCache=new DeviceCache(targets);
+        DeviceManager deviceManager=new DeviceManager(deviceCache);
+        Predicate<TargetDetails> predicate = getTargetDetailsPredicate( "Google","android");
+
+        deviceCache.lock("321");
+        deviceCache.lock("236");
+
+        Assertions.assertFalse(deviceCache.isAvailable(predicate));
+        deviceManager.releaseDevice(pixel3);
+        Assertions.assertTrue(deviceCache.isAvailable(predicate));
+    }
+
+    private TargetDetails getTargetDetails() {
+        TargetDetails pixel =
+                TargetDetails.builder()
+                        .platform(EkamSupportedPlatforms.ANDROID)
+                        .name("Google Pixel "+UUID.randomUUID().toString())
+                        .udid(UUID.randomUUID().toString())
+                        .build();
+        return pixel;
+    }
 
     private Predicate<TargetDetails> getTargetDetailsPredicate(String deviceName, String devicePlatform) {
         DeviceFilter modelFilter =
@@ -80,6 +119,13 @@ public class DeviceEngagedTests {
         DeviceFilters filters =
                 DeviceFilters.builder()
                         .model(modelFilter)
+                        .build();
+        return new DeviceFiltersManager().createDeviceFilters(devicePlatform,filters);
+    }
+
+    private Predicate<TargetDetails> getTargetDetailsPredicate(String devicePlatform) {
+        DeviceFilters filters =
+                DeviceFilters.builder()
                         .build();
         return new DeviceFiltersManager().createDeviceFilters(devicePlatform,filters);
     }

--- a/src/test/java/com/testvagrant/ekam/devicemanager/devicecache/DeviceEngagedTests.java
+++ b/src/test/java/com/testvagrant/ekam/devicemanager/devicecache/DeviceEngagedTests.java
@@ -1,0 +1,87 @@
+package com.testvagrant.ekam.devicemanager.devicecache;
+
+import com.testvagrant.ekam.devicemanager.DeviceCache;
+import com.testvagrant.ekam.devicemanager.DeviceFiltersManager;
+import com.testvagrant.ekam.devicemanager.DeviceManager;
+import com.testvagrant.ekam.devicemanager.models.DeviceFilter;
+import com.testvagrant.ekam.devicemanager.models.DeviceFilters;
+import com.testvagrant.ekam.devicemanager.models.EkamSupportedPlatforms;
+import com.testvagrant.ekam.devicemanager.models.TargetDetails;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.List;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
+
+public class DeviceEngagedTests {
+
+    @Test
+    public void shouldGiveDifferentDevicesWhenTheDeviceLockIsEnabled(){
+        TargetDetails pixel3a=
+                TargetDetails.builder()
+                        .platform(EkamSupportedPlatforms.ANDROID)
+                        .name("Google Pixel 3a")
+                        .udid("12")
+                        .build();
+        TargetDetails pixel3b =
+                TargetDetails.builder()
+                        .platform(EkamSupportedPlatforms.ANDROID)
+                        .name("Google Pixel 3b")
+                        .udid("12")
+                        .build();
+
+        List<TargetDetails>targets=List.of(pixel3a,pixel3b);
+
+        DeviceCache deviceCache=new DeviceCache(targets);
+
+        Predicate<TargetDetails> predicate = getTargetDetailsPredicate("Google Pixel 3", "android");
+
+        TargetDetails availableDevice = new DeviceManager(deviceCache).getAvailableDevice(predicate, true);
+        TargetDetails availableDevice1 = new DeviceManager(deviceCache).getAvailableDevice(predicate, true);
+        TargetDetails availableDevice2 = new DeviceManager(deviceCache).getAvailableDevice(predicate, true);
+
+        Assertions.assertNotEquals(availableDevice.getName(),availableDevice1.getName());
+    }
+    @Test
+    public void shouldGiveSameDeviceWhenTheDeviceLockIsDisabled(){
+        TargetDetails pixel3c=
+                TargetDetails.builder()
+                        .platform(EkamSupportedPlatforms.ANDROID)
+                        .name("Google Pixel 3c")
+                        .udid("12")
+                        .build();
+
+        TargetDetails pixel3b =
+                TargetDetails.builder()
+                        .platform(EkamSupportedPlatforms.ANDROID)
+                        .name("Google Pixel 3b")
+                        .udid("12")
+                        .build();
+
+        List<TargetDetails>targets=List.of(pixel3c,pixel3b);
+
+        DeviceCache deviceCache=new DeviceCache(targets);
+
+        Predicate<TargetDetails> predicate = getTargetDetailsPredicate("Google Pixel 3", "android");
+
+        TargetDetails availableDevice = new DeviceManager(deviceCache).getAvailableDevice(predicate, false);
+        TargetDetails availableDevice1 = new DeviceManager(deviceCache).getAvailableDevice(predicate, false);
+        TargetDetails availableDevice2 = new DeviceManager(deviceCache).getAvailableDevice(predicate, false);
+
+        Assertions.assertEquals(availableDevice.getName().toString(),availableDevice1.getName().toString());
+    }
+
+
+    private Predicate<TargetDetails> getTargetDetailsPredicate(String deviceName, String devicePlatform) {
+        DeviceFilter modelFilter =
+                DeviceFilter.builder()
+                        .include(List.of(deviceName))
+                        .build();
+        DeviceFilters filters =
+                DeviceFilters.builder()
+                        .model(modelFilter)
+                        .build();
+        return new DeviceFiltersManager().createDeviceFilters(devicePlatform,filters);
+    }
+
+}


### PR DESCRIPTION
* Added capability to override **Browserstack** and **Pcloudy** cache lock
* Override using System property **-D<cloud.browserstack.cache.lock/cloud.pcloudy.cache.lock>=<true/false>**
* Changed the logic to provide **random device** when the lock is **disabled**